### PR TITLE
fix session authentication overlap

### DIFF
--- a/github-fixed-header.user.css
+++ b/github-fixed-header.user.css
@@ -18,7 +18,8 @@
   .is-stuck {
     padding-top: var(--height) !important;
   }
-  body.logged-out:not(.f4) {
+  body.logged-out:not(.f4),
+  body.session-authentication {
     padding-top: 89px !important;
   }
   .pr-toolbar.is-stuck .diffbar {


### PR DESCRIPTION
"Confirm password to continue" text overlaps the Github logo.